### PR TITLE
Makefile improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,3 +86,5 @@ install:
 
 clean:
 	rm -f $(EXECUTABLE) $(OBJECTS)
+
+.PHONY: all install clean release debug


### PR DESCRIPTION
I did add a new target (install) and declare PHONY targets to the makefile to make it able to install the software in a standard fashion; and to prevent any misbehavior should a file with a name conflicting with a phony target exist.
