### PR TITLE
Improve command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ Running
 -------
 
 ```sh
-./hhpc <options>
+./hhpc [options]
 
-  -i <seconds>: amount of time to wait before hiding the cursor
+  -i seconds: amount of time to wait before hiding the cursor
+  -h: display a help message
   -v: be verbose
 ```
 


### PR DESCRIPTION
* Return with non-zero status when there are any extra arguments.
* Add option (-h) to display help message.
* Clarify help message by writing "[-i seconds]" instead of "[-i] seconds" and adding descriptions of each option.